### PR TITLE
Update catalog domain to github.io

### DIFF
--- a/giantswarm-catalog-full.yaml
+++ b/giantswarm-catalog-full.yaml
@@ -20,4 +20,4 @@ spec:
   logoURL: "https://s.giantswarm.io/..."
   storage:
     type: helm
-    URL: "https://giantswarm.github.com/app-catalog/"
+    URL: "https://giantswarm.github.io/app-catalog/"

--- a/giantswarm-catalog-wo-label.yaml
+++ b/giantswarm-catalog-wo-label.yaml
@@ -19,4 +19,4 @@ spec:
   logoURL: "https://s.giantswarm.io/..."
   storage:
     type: helm
-    URL: "https://giantswarm.github.com/app-catalog/"
+    URL: "https://giantswarm.github.io/app-catalog/"


### PR DESCRIPTION
Updates the catalog domain to giantswarm.github.io instead of giantswarm.github.com. Towards giantswarm/giantswarm#15898